### PR TITLE
Add Swagger OpenAPI support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,13 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Swagger/OpenAPI documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/demo/config/OpenApiConfig.java
+++ b/src/main/java/com/example/demo/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.example.demo.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Demo API")
+                        .version("1.0")
+                        .description("Demo project for Spring Boot"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Springdoc OpenAPI starter dependency for Swagger UI
- configure OpenAPI bean with basic API information

## Testing
- `mvn dependency:tree` *(fails: Network is unreachable)*
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cb181690c832a88fb2a6848111e12